### PR TITLE
Typespec Generation for Embedded Schema

### DIFF
--- a/lib/strukt.ex
+++ b/lib/strukt.ex
@@ -31,8 +31,8 @@ defmodule Strukt do
 
   NOTE: It is recommended that if you need to perform custom validations, that
   you use the `validation/1` and `validation/2` facility for performing custom
-  validations in a module or function, and if necessary, override `c:validate/1` 
-  instead of performing validations in this callback. If you need to override this 
+  validations in a module or function, and if necessary, override `c:validate/1`
+  instead of performing validations in this callback. If you need to override this
   callback specifically for some reason, make sure you call `super/2` at some point during
   your implementation to ensure that validations are run.
   """

--- a/test/strukt_test.exs
+++ b/test/strukt_test.exs
@@ -521,6 +521,39 @@ defmodule Strukt.Test do
              Fixtures.TypeSpec.expected_type_spec_ast_str()
   end
 
+  test "can generate simple type spec and nullable respect default/required setting with embeds schema" do
+    require Fixtures.TypeSpecWithEmbesModule
+
+    assert inspect(
+             Strukt.Typespec.generate(%Strukt.Typespec{
+               caller: Strukt.Test.Fixtures.TypeSpecWithEmbesModule,
+               fields: [:optional_field],
+               info: %{
+                 optional_field: %{
+                   type: :field,
+                   value_type: :integer,
+                   required: false,
+                   default: nil
+                 },
+                 type_specs: %{
+                   type: :embeds_many,
+                   value_type: Strukt.Test.Fixtures.TypeSpec,
+                   required: false,
+                   default: nil
+                 },
+                 type_spec: %{
+                   type: :embeds_one,
+                   value_type: Strukt.Test.Fixtures.TypeSpec,
+                   required: true,
+                   default: nil
+                 }
+               },
+               embeds: [:type_spec, :type_specs]
+             })
+           ) ==
+             Fixtures.TypeSpecWithEmbesModule.expected_type_spec_ast_str()
+  end
+
   defp changeset_errors(%Ecto.Changeset{} = cs) do
     cs
     |> Ecto.Changeset.traverse_errors(fn {msg, opts} ->

--- a/test/support/defstruct_fixtures.ex
+++ b/test/support/defstruct_fixtures.ex
@@ -22,10 +22,10 @@ defmodule Strukt.Test.Fixtures do
 
     @primary_key false
     defstruct do
-      field(:required_filed, :string, required: true)
-      field(:optional_field, :string)
-      field(:default_field, :string, default: "")
-      field(:default_nil_field, :string, default: nil)
+      field(:required_filed, :integer, required: true)
+      field(:optional_field, :integer)
+      field(:default_field, :integer, default: 100)
+      field(:default_nil_field, :integer, default: nil)
     end
 
     defmacro expected_type_spec_ast_str do
@@ -35,6 +35,28 @@ defmodule Strukt.Test.Fixtures do
                 optional_field: integer() | nil,
                 default_field: integer(),
                 default_nil_field: integer() | nil
+              }
+      end
+      |> inspect()
+    end
+  end
+
+  defmodule TypeSpecWithEmbesModule do
+    use Strukt
+
+    @primary_key false
+    defstruct do
+      field(:optional_field, :integer)
+      embeds_one(:type_spec, TypeSpec, required: true)
+      embeds_many(:type_specs, TypeSpec)
+    end
+
+    defmacro expected_type_spec_ast_str do
+      quote context: __MODULE__ do
+        @type t :: %__MODULE__{
+                optional_field: integer() | nil,
+                type_spec: TypeSpec.t(),
+                type_specs: [TypeSpec.t()] | nil
               }
       end
       |> inspect()


### PR DESCRIPTION
### Context
We can specify whether the embedded schema is required or not, but the typespec doesn't reflect that accordingly. 

### What's Changed
- update `TypeSpec` module in `test/support/defstruct_fixtures.ex` to fit the test case.
- add `__MODULE__ | nil` scenario for embeds_one and embeds_many