### PR TITLE
fix: `Regex.regex?` is deprecated warning

### DIFF
--- a/lib/validation.ex
+++ b/lib/validation.ex
@@ -78,7 +78,7 @@ defmodule Strukt.Validation do
 
           :format ->
             cond do
-              Regex.regex?(data_or_opts) ->
+              is_struct(data_or_opts, Regex) ->
                 quote do
                   Ecto.Changeset.validate_format(
                     unquote(field),


### PR DESCRIPTION
fixed this warning
```
==> strukt
Compiling 8 files (.ex)
warning: Regex.regex?/1 is deprecated. Use Kernel.is_struct(term, Regex) or pattern match on %Regex{} instead
  lib/validation.ex:81: Strukt.Validation.generate_body/2
```